### PR TITLE
updated autogen.sh to pass command-line arguments on to configure

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -4,4 +4,4 @@ autoreconf --verbose --install --symlink --force
 autoreconf --verbose --install --symlink --force
 autoreconf --verbose --install --symlink --force
 
-./configure --enable-maintainer-mode
+./configure --enable-maintainer-mode "$@"


### PR DESCRIPTION
`autogen.sh` was not passing its command-line arguments on to `configure`, complicating standard scripts for automated fetch-and-build 