### PR TITLE
Clean MSan warnings

### DIFF
--- a/check.h
+++ b/check.h
@@ -29,7 +29,7 @@
 
 #define CHK_MALLOC(p, t, n) do {                              \
      size_t CHK_MALLOC_n_tmp = (n);                           \
-     (p) = (t *) malloc(sizeof(t) * CHK_MALLOC_n_tmp);        \
+     (p) = (t *) calloc(CHK_MALLOC_n_tmp, sizeof(t));         \
      CHECK((p) || CHK_MALLOC_n_tmp == 0, "out of memory!");   \
 } while (0)
 

--- a/harminv.c
+++ b/harminv.c
@@ -460,7 +460,7 @@ static cmplx symmetric_dot(int n, cmplx *x, cmplx *y)
    conjugation). */
 static void solve_eigenvects(int n, const cmplx *A0, cmplx *V, cmplx *v)
 {
-     int lwork, info;
+     int lwork, info = 0;
      cmplx *work;
      double *rwork;
      cmplx *A;


### PR DESCRIPTION
1. Changed to `calloc` to create and initialize arrays.
2. Initialized `info` before using.