### PR TITLE
windows (mingw64) fixes 

### DIFF
--- a/harminv-main.c
+++ b/harminv-main.c
@@ -61,7 +61,6 @@ static int eat_whitespace(FILE *f, int echo_comments)
      } while (isspace (c));
      ungetc(c, f); /* put back the last character read */
      newlines -= c == '\n';
-	 
      return newlines;
 }
 

--- a/harminv-main.c
+++ b/harminv-main.c
@@ -90,10 +90,8 @@ static cmplx *read_input_data(FILE *f, int *n, int verbose)
      do {
 	  double re=0.0, im=0.0;
 	  int nread;
-	  newlines =  eat_whitespace(f, verbose);
-	  if (newlines == -1)
-		break;
-	  
+	  newlines = eat_whitespace(f, verbose);
+	  if (newlines == -1) break;
 	  line += newlines;
 	  nread = fscanf(f, "%lg", &re);
 	  if (nread == 1 && eat_plus(f)) {

--- a/harminv-main.c
+++ b/harminv-main.c
@@ -59,9 +59,8 @@ static int eat_whitespace(FILE *f, int echo_comments)
 	       } while (c != EOF && c != '\n');
 	  }
      } while (isspace (c));
-	 
-	 ungetc(c, f); /* put back the last character read */
-	 newlines -= c == '\n';
+     ungetc(c, f); /* put back the last character read */
+     newlines -= c == '\n';
 	 
      return newlines;
 }

--- a/harminv-main.c
+++ b/harminv-main.c
@@ -59,7 +59,7 @@ static int eat_whitespace(FILE *f, int echo_comments)
 	       } while (c != EOF && c != '\n');
 	  }
      } while (isspace (c));
-     if (c == -1) return -1;
+     if (c == -1) return -1; /* eof */
      ungetc(c, f); /* put back the last character read */
      newlines -= c == '\n';
      return newlines;

--- a/harminv-main.c
+++ b/harminv-main.c
@@ -59,13 +59,10 @@ static int eat_whitespace(FILE *f, int echo_comments)
 	       } while (c != EOF && c != '\n');
 	  }
      } while (isspace (c));
-	 if (c==-1){
-		return -1;
-  	 }
-	 else{
-		ungetc(c, f); /* put back the last character read */
-		newlines -= c == '\n';
-	 }
+	 
+	 ungetc(c, f); /* put back the last character read */
+	 newlines -= c == '\n';
+	 
      return newlines;
 }
 
@@ -94,11 +91,7 @@ static cmplx *read_input_data(FILE *f, int *n, int verbose)
      do {
 	  double re=0.0, im=0.0;
 	  int nread;
-	  newlines =  eat_whitespace(f, verbose);
-	  if (newlines == -1)
-		break;
-	  
-	  line += newlines;
+	  line += eat_whitespace(f, verbose);
 	  nread = fscanf(f, "%lg", &re);
 	  if (nread == 1 && eat_plus(f)) {
 	       nread = fscanf(f, "%lg", &im);

--- a/harminv-main.c
+++ b/harminv-main.c
@@ -59,13 +59,9 @@ static int eat_whitespace(FILE *f, int echo_comments)
 	       } while (c != EOF && c != '\n');
 	  }
      } while (isspace (c));
-	 if (c==-1){
-		return -1;
-  	 }
-	 else{
-		ungetc(c, f); /* put back the last character read */
-		newlines -= c == '\n';
-	 }
+     if (c==-1) return -1;
+     ungetc(c, f); /* put back the last character read */
+     newlines -= c == '\n';
      return newlines;
 }
 

--- a/harminv-main.c
+++ b/harminv-main.c
@@ -84,15 +84,16 @@ static int eat_i(FILE *f)
 static cmplx *read_input_data(FILE *f, int *n, int verbose)
 {
     cmplx *data = NULL;
-    int line = 1, n_alloc = 0, newlines=0;
+    int line = 1, n_alloc = 0;
     *n = 0;
 
      do {
 	  double re=0.0, im=0.0;
 	  int nread;
-	  newlines = eat_whitespace(f, verbose);
-	  if (newlines == -1) break;
-	  line += newlines;
+	  int whitespace_lines = eat_whitespace(f, verbose);
+	  if (whitespace_lines == -1) break; /* eof */
+	  line += whitespace_lines;
+	  
 	  nread = fscanf(f, "%lg", &re);
 	  if (nread == 1 && eat_plus(f)) {
 	       nread = fscanf(f, "%lg", &im);

--- a/harminv-main.c
+++ b/harminv-main.c
@@ -59,7 +59,7 @@ static int eat_whitespace(FILE *f, int echo_comments)
 	       } while (c != EOF && c != '\n');
 	  }
      } while (isspace (c));
-     if (c==-1) return -1;
+     if (c == -1) return -1;
      ungetc(c, f); /* put back the last character read */
      newlines -= c == '\n';
      return newlines;


### PR DESCRIPTION
* if the output of sines generates an empty last line, a -1 char is returned somehow. `read_input_data` couldn't handle that
* multiplying inf with the min_err (e.g. 0) gives a NaN on windows/mingw64 (-1#INDe000) that won't compare with errk