### PR TITLE
Fix bug in `SORT_AMPLITUDE` comparator case

### DIFF
--- a/harminv-main.c
+++ b/harminv-main.c
@@ -166,7 +166,7 @@ static int compar(const void *a, const void *b) {
     case SORT_ERROR: return cmp(harminv_get_freq_error(hd, *ia), harminv_get_freq_error(hd, *ib));
     case SORT_AMPLITUDE:
       harminv_get_amplitude(&aa, hd, *ia);
-      harminv_get_amplitude(&ab, hd, *ia);
+      harminv_get_amplitude(&ab, hd, *ib);
       return cmp(cabs(aa), cabs(ab));
     case SORT_Q:
       return cmp(harminv_get_freq(hd, *ia) / harminv_get_decay(hd, *ia),


### PR DESCRIPTION
In the `SORT_AMPLITUDE` case of the comparator switch `sortby` in `harminv-main.c`, the second call `harminv_get_amplitude(&ab, hd, *ia)` uses `*ia` instead of `*ib`. This fetches the amplitude for the same element twice, making the amplitude-based sort always compare an element against itself (returning 0). Every other case in this switch correctly uses `*ib` for the second operand.